### PR TITLE
Installation and use of SRILM maxent LMs

### DIFF
--- a/egs/scale-pashto/s5/local/train_lms_srilm.sh
+++ b/egs/scale-pashto/s5/local/train_lms_srilm.sh
@@ -8,7 +8,8 @@ oov_symbol="<UNK>"
 
 echo "$0 $@"
 
-. ./utils/parse_options.sh
+if [ -f path.sh ]; then . path.sh; fi
+. ./utils/parse_options.sh || exit 1
 
 echo "-------------------------------------"
 echo "Building an SRILM language model     "
@@ -134,6 +135,18 @@ ngram-count -lm $tgtdir/3gram.kn012.gz -kndiscount1 -gt1min 0 -kndiscount2 -gt2m
 ngram-count -lm $tgtdir/3gram.kn022.gz -kndiscount1 -gt1min 0 -kndiscount2 -gt2min 2 -kndiscount3 -gt3min 2 -order 3 -text $tgtdir/train.txt -vocab $tgtdir/vocab -unk -sort -map-unk "$oov_symbol"
 ngram-count -lm $tgtdir/3gram.kn023.gz -kndiscount1 -gt1min 0 -kndiscount2 -gt2min 2 -kndiscount3 -gt3min 3 -order 3 -text $tgtdir/train.txt -vocab $tgtdir/vocab -unk -sort -map-unk "$oov_symbol"
 
+if [ ! -z ${LIBLBFGS} ]; then 
+	
+    echo "-------------------"
+    echo "Maxent 3grams"
+    echo "-------------------"
+    #-map-unk "$oov_symbol" - if this is used with -maxent-convert-to-arpa, ngram-count will segfault   
+    ngram-count -lm - -kndiscount1 -order 3 -text $tgtdir/train.txt -vocab $tgtdir/vocab -unk -sort \
+        -maxent -maxent-convert-to-arpa | sed "s/<unk>/${oov_symbol}/" | gzip -c > $tgtdir/3gram.me.gz || exit 1
+
+
+fi
+    
 
 echo "-------------------"
 echo "Good-Turing 4grams"
@@ -156,6 +169,17 @@ ngram-count -lm $tgtdir/4gram.kn0122.gz -kndiscount1 -gt1min 0 -kndiscount2 -gt2
 ngram-count -lm $tgtdir/4gram.kn0123.gz -kndiscount1 -gt1min 0 -kndiscount2 -gt2min 1 -kndiscount3 -gt3min 2 -kndiscount4 -gt4min 3 -order 4 -text $tgtdir/train.txt -vocab $tgtdir/vocab -unk -sort -map-unk "$oov_symbol"
 ngram-count -lm $tgtdir/4gram.kn0222.gz -kndiscount1 -gt1min 0 -kndiscount2 -gt2min 2 -kndiscount3 -gt3min 2 -kndiscount4 -gt4min 2 -order 4 -text $tgtdir/train.txt -vocab $tgtdir/vocab -unk -sort -map-unk "$oov_symbol"
 ngram-count -lm $tgtdir/4gram.kn0223.gz -kndiscount1 -gt1min 0 -kndiscount2 -gt2min 2 -kndiscount3 -gt3min 2 -kndiscount4 -gt4min 3 -order 4 -text $tgtdir/train.txt -vocab $tgtdir/vocab -unk -sort -map-unk "$oov_symbol"
+
+if [ ! -z ${LIBLBFGS} ]; then 
+    echo "-------------------"
+    echo "Maxent 4grams"
+    echo "-------------------"
+    #-map-unk "$oov_symbol" - if this is used with -maxent-convert-to-arpa, ngram-count will segfault
+    ngram-count -lm - -kndiscount1 -order 4 -text $tgtdir/train.txt -vocab $tgtdir/vocab -unk -sort \
+        -maxent -maxent-convert-to-arpa | sed "s/<unk>/${oov_symbol}/" | gzip -c > $tgtdir/4gram.me.gz || exit 1
+
+fi
+
 
 echo "--------------------"
 echo "Computing perplexity"

--- a/tools/extras/install_liblbfgs.sh
+++ b/tools/extras/install_liblbfgs.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+VER=1.10
+if [ ! -f $liblbfgs-$VER.tar.gz ]; then
+  wget https://github.com/downloads/chokkan/liblbfgs/liblbfgs-$VER.tar.gz
+fi
+
+tar -xzf liblbfgs-$VER.tar.gz
+cd liblbfgs-$VER
+./configure
+make
+cd ..
+
+(
+  [ ! -z ${LIBLBFGS} ] && \
+    echo >&2 "LIBLBFGS variable is aleady defined. Undefining..." && \
+    unset LIBLBFGS
+
+  [ -f ./env.sh ] && . ./env.sh
+
+  [ ! -z ${LIBLBFGS} ] && \
+    echo >&2 "libLBFGS config is already in env.sh" && exit
+
+  wd=`pwd`
+  wd=`readlink -f $wd || pwd`
+
+  echo "export LIBLBFGS=$wd/liblbfgs-1.10"
+  echo export LD_LIBRARY_PATH='${LD_LIBRARY_PATH}':'${LIBLBFGS}'/lib/.libs
+) >> env.sh
+

--- a/tools/extras/install_srilm.sh
+++ b/tools/extras/install_srilm.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
-# http://www.speech.sri.com/projects/srilm/download.html
+if [ ! -f liblbfgs-1.10 ]; then
+    echo Intalling libLBFGS library to support MaxEnt LMs
+    bash install_liblbfgs.sh
+fi
 
+# http://www.speech.sri.com/projects/srilm/download.html
 if [ ! -f srilm.tgz ]; then
   echo This script cannot install SRILM in a completely automatic
   echo way because you need to put your address in a download form.
@@ -22,6 +26,19 @@ cp Makefile tmpf
 
 cat tmpf | awk -v pwd=`pwd` '/SRILM =/{printf("SRILM = %s\n", pwd); next;} {print;}' \
   > Makefile || exit 1;
+
+mtype=`sbin/machine-type`
+
+echo HAVE_LIBLBFGS=1 >> common/Makefile.machine.$mtype 
+grep ADDITIONAL_INCLUDES common/Makefile.machine.$mtype | \
+    sed 's|$| -I$(SRILM)/../liblbfgs-1.10/include|' \
+    >> common/Makefile.machine.$mtype 
+
+grep ADDITIONAL_LDFLAGS common/Makefile.machine.$mtype | \
+    sed 's|$| -L$(SRILM)/../liblbfgs-1.10/lib/.libs|' \
+    >> common/Makefile.machine.$mtype 
+
+
 
 make
 

--- a/tools/install_liblbfgs.sh
+++ b/tools/install_liblbfgs.sh
@@ -1,0 +1,1 @@
+extras/install_liblbfgs.sh


### PR DESCRIPTION
Added support to download and build the libLBFGS library, required by the SRILM toolkit for maxent LMs, and modfied train_lms_srilm.sh to build maxent LMs and store in ARPA format.
